### PR TITLE
Remove AWS dependency

### DIFF
--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -11,7 +11,7 @@ A comprehensive browser-based PowerPoint template personalization tool that enab
 ```
 ┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐
 │   Frontend      │    │   Backend       │    │   Storage       │
-│   (Next.js)     │◄──►│   (FastAPI)     │◄──►│   (AWS S3)      │
+│   (Next.js)     │◄──►│   (FastAPI)     │◄──►│ (Local/S3)      │
 │                 │    │                 │    │                 │
 │ • React UI      │    │ • python-pptx   │    │ • File Storage  │
 │ • File Upload   │    │ • Processing    │    │ • Presigned URLs│
@@ -147,15 +147,11 @@ npm run build
 vercel deploy
 ```
 
-### Backend (AWS)
+### Backend (Optional AWS)
 ```bash
 # Docker deployment
 docker build -t pptx-templater-api .
-docker push ecr-repo-url
-
-# Lambda deployment
-pip install mangum
-# Deploy with AWS SAM or CDK
+# Deploy to any container platform. AWS Lambda is optional and requires Mangum.
 ```
 
 ## 🔮 Future Roadmap

--- a/pptx-backend/README.md
+++ b/pptx-backend/README.md
@@ -165,18 +165,8 @@ COPY . .
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
 ```
 
-### AWS Lambda
-The application can be deployed to AWS Lambda using Mangum:
-```bash
-pip install mangum
-```
-
-### Environment Variables
-```bash
-export AWS_ACCESS_KEY_ID=your_key
-export AWS_SECRET_ACCESS_KEY=your_secret
-export S3_BUCKET_NAME=your_bucket
-```
+### Deployment
+Run the application locally with Uvicorn or package it in a Docker container for deployment to any platform. AWS Lambda is optional and not required for local use.
 
 ## 📊 Performance
 
@@ -192,9 +182,9 @@ export S3_BUCKET_NAME=your_bucket
 - Temporary file cleanup
 - CORS configuration
 
-## 🔮 Future Enhancements
+ ## 🔮 Future Enhancements
 
-- **S3 Integration**: Direct upload/download with presigned URLs
+- **Optional S3 Integration**: Direct upload/download with presigned URLs
 - **Queue System**: SQS for background processing
 - **Caching**: Redis for processed templates
 - **Monitoring**: CloudWatch metrics and alarms

--- a/pptx-backend/requirements.txt
+++ b/pptx-backend/requirements.txt
@@ -4,8 +4,8 @@ python-pptx==0.6.23
 python-multipart==0.0.6
 pillow==10.1.0
 cairosvg==2.7.1
-boto3==1.34.0
 pydantic==2.5.0
 python-dotenv==1.0.0
+httpx==0.25.2
 pytest==7.4.3
-pytest-asyncio==0.21.1 
+pytest-asyncio==0.21.1

--- a/pptx-backend/test_main.py
+++ b/pptx-backend/test_main.py
@@ -37,11 +37,11 @@ def test_process_endpoint_invalid_file_type():
     assert response.status_code == 400
     assert "File must be a .pptx file" in response.json()["detail"]
 
-def test_download_endpoint_not_implemented():
-    """Test download endpoint returns not implemented"""
+def test_download_endpoint_missing_file():
+    """Test download endpoint when file is not found"""
     response = client.get("/download/test.pptx")
-    assert response.status_code == 501
-    assert "not implemented" in response.json()["detail"]
+    assert response.status_code == 404
+    assert "File not found" in response.json()["detail"]
 
 # Integration tests would require actual PPTX files
 # These would be added in a full test suite 


### PR DESCRIPTION
## Summary
- remove boto3 dependency and add httpx for testing
- clarify that AWS deployment is optional
- update future enhancement note about S3
- update architecture overview diagram
- fix download endpoint test to expect 404

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `pip install -r requirements.txt` *(fails: No route to host)*