### PR TITLE
Fix download path sanitization

### DIFF
--- a/pptx-backend/main.py
+++ b/pptx-backend/main.py
@@ -124,14 +124,18 @@ async def process_pptx(
 @app.get("/download/{filename}")
 async def download_file(filename: str):
     """Download processed PPTX file"""
-    file_path = os.path.join(TEMP_OUTPUT_DIR, filename)
-    
-    if not os.path.exists(file_path):
+    # Resolve the absolute path and ensure it stays within TEMP_OUTPUT_DIR
+    sanitized_path = os.path.abspath(os.path.join(TEMP_OUTPUT_DIR, filename))
+
+    if not sanitized_path.startswith(os.path.abspath(TEMP_OUTPUT_DIR)):
+        raise HTTPException(status_code=400)
+
+    if not os.path.exists(sanitized_path):
         raise HTTPException(status_code=404, detail="File not found")
-    
+
     # Return the file with proper headers for download
     return FileResponse(
-        path=file_path,
+        path=sanitized_path,
         filename=filename,
         media_type="application/vnd.openxmlformats-officedocument.presentationml.presentation"
     )

--- a/pptx-backend/test_main.py
+++ b/pptx-backend/test_main.py
@@ -37,11 +37,15 @@ def test_process_endpoint_invalid_file_type():
     assert response.status_code == 400
     assert "File must be a .pptx file" in response.json()["detail"]
 
-def test_download_endpoint_not_implemented():
-    """Test download endpoint returns not implemented"""
+def test_download_endpoint_missing_file():
+    """Test download endpoint for non-existent file"""
     response = client.get("/download/test.pptx")
-    assert response.status_code == 501
-    assert "not implemented" in response.json()["detail"]
+    assert response.status_code == 404
+
+def test_download_prevents_path_traversal():
+    """Ensure directory traversal is rejected"""
+    response = client.get("/download/../secret.txt")
+    assert response.status_code == 400
 
 # Integration tests would require actual PPTX files
 # These would be added in a full test suite 


### PR DESCRIPTION
## Summary
- sanitize the download path to prevent traversal attacks
- update unit tests for new download behavior and traversal check

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*