### PR TITLE
Fix DATE placeholder docs

### DIFF
--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -68,7 +68,7 @@ Coding/
 
 ### Backend (FastAPI + Python)
 - ✅ **PPTX Processing**: python-pptx for template manipulation
-- ✅ **Placeholder Replacement**: {{COMPANY_NAME}}, {{DATE}}, {{LOGO}}
+ - ✅ **Placeholder Replacement**: {{COMPANY_NAME}}, {{DATE_LONG}}, {{LOGO}}
 - ✅ **Logo Scaling**: Aspect ratio preservation, no upscaling
 - ✅ **Date Formatting**: Ordinal format (24th May 2025)
 - ✅ **File Validation**: Type and size checking

--- a/pptx-backend/README.md
+++ b/pptx-backend/README.md
@@ -4,7 +4,7 @@ FastAPI backend service for processing PowerPoint templates with placeholder rep
 
 ## 🚀 Features
 
-- **PPTX Processing**: Replace `{{COMPANY_NAME}}`, `{{DATE}}`, and `{{LOGO}}` placeholders
+ - **PPTX Processing**: Replace `{{COMPANY_NAME}}`, `{{DATE_LONG}}`, and `{{LOGO}}` placeholders
 - **Logo Handling**: Auto-scale logos to fit bounding boxes while preserving aspect ratio
 - **Date Formatting**: Convert dates to ordinal format (e.g., "24th May 2025")
 - **File Validation**: Validate PPTX files and image formats
@@ -82,7 +82,7 @@ Health check endpoint.
 Your PowerPoint template should contain these placeholders:
 
 - `{{COMPANY_NAME}}` - Replaced with company name in text
-- `{{DATE}}` - Replaced with formatted date (e.g., "24th May 2025")
+ - `{{DATE_LONG}}` - Replaced with formatted date (e.g., "24th May 2025")
 - `{{LOGO}}` - Replaced with uploaded logo image
 
 ### Logo Placement

--- a/pptx-backend/main.py
+++ b/pptx-backend/main.py
@@ -60,7 +60,7 @@ async def process_pptx(
     Args:
         file: PPTX template file
         company_name: Company name to replace {{COMPANY_NAME}} placeholders
-        date: Date string to format and replace {{DATE}} placeholders
+        date: Date string to format and replace {{DATE_LONG}} placeholders
         logo: Optional logo image to replace {{LOGO}} placeholders
     
     Returns:

--- a/pptx-backend/pptx_processor.py
+++ b/pptx-backend/pptx_processor.py
@@ -38,7 +38,7 @@ class PPTXProcessor:
             input_path: Path to input PPTX file
             output_path: Path for output PPTX file
             company_name: Company name to replace {{COMPANY_NAME}} placeholders
-            date: Formatted date string to replace {{DATE}} placeholders
+            date: Formatted date string to replace {{DATE_LONG}} placeholders
             logo_path: Optional path to logo image for {{LOGO}} placeholders
         """
         


### PR DESCRIPTION
## Summary
- use `{{DATE_LONG}}` placeholder in backend docs and comments
- keep docs aligned with code using the new placeholder

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*