### PR TITLE
Fix missing frontend modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -232,4 +232,6 @@ Thumbs.db
 *.tmp
 *.temp
 temp/
-tmp/ 
+tmp/
+
+!pptx-templater/src/lib/

--- a/pptx-templater/src/lib/api.ts
+++ b/pptx-templater/src/lib/api.ts
@@ -1,0 +1,43 @@
+export interface ProcessTemplateResponse {
+  success: boolean
+  filename: string
+  download_url: string
+  message: string
+}
+
+/**
+ * Send a PPTX template and associated data to the backend for processing.
+ * @param file The PowerPoint template file.
+ * @param companyName Company name to replace placeholders.
+ * @param date Date of the presentation.
+ * @param logo Optional logo image file.
+ */
+export async function processTemplate(
+  file: File,
+  companyName: string,
+  date: Date,
+  logo?: File
+): Promise<ProcessTemplateResponse> {
+  const API_BASE_URL =
+    process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:8000'
+
+  const formData = new FormData()
+  formData.append('file', file)
+  formData.append('company_name', companyName)
+  formData.append('date', date.toISOString())
+  if (logo) {
+    formData.append('logo', logo)
+  }
+
+  const res = await fetch(`${API_BASE_URL}/process`, {
+    method: 'POST',
+    body: formData,
+  })
+
+  if (!res.ok) {
+    const errorText = await res.text()
+    throw new Error(errorText || 'Failed to process template')
+  }
+
+  return (await res.json()) as ProcessTemplateResponse
+}

--- a/pptx-templater/src/lib/utils.ts
+++ b/pptx-templater/src/lib/utils.ts
@@ -1,0 +1,10 @@
+import { type ClassValue, clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+/**
+ * Utility function for conditional class names.
+ * Combines clsx with tailwind-merge to deduplicate classes.
+ */
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}


### PR DESCRIPTION
## Summary
- restore missing `@/lib` modules for Next.js app
- update `.gitignore` to allow committing `src/lib`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `npm run build` *(fails: `next` not found)*