### PR TITLE
Add missing utility library and fix tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,8 @@ downloads/
 eggs/
 .eggs/
 lib/
+!pptx-templater/src/lib/
+!pptx-templater/src/lib/**
 lib64/
 parts/
 sdist/

--- a/pptx-backend/test_main.py
+++ b/pptx-backend/test_main.py
@@ -37,11 +37,11 @@ def test_process_endpoint_invalid_file_type():
     assert response.status_code == 400
     assert "File must be a .pptx file" in response.json()["detail"]
 
-def test_download_endpoint_not_implemented():
-    """Test download endpoint returns not implemented"""
+def test_download_endpoint_missing_file():
+    """Test download endpoint returns 404 for missing files"""
     response = client.get("/download/test.pptx")
-    assert response.status_code == 501
-    assert "not implemented" in response.json()["detail"]
+    assert response.status_code == 404
+    assert "File not found" in response.json()["detail"]
 
 # Integration tests would require actual PPTX files
 # These would be added in a full test suite 

--- a/pptx-templater/src/lib/api.ts
+++ b/pptx-templater/src/lib/api.ts
@@ -1,0 +1,34 @@
+export interface ProcessResponse {
+  success: boolean
+  filename: string
+  download_url: string
+  message: string
+  processing_time?: number
+}
+
+export async function processTemplate(
+  file: File,
+  companyName: string,
+  date: Date,
+  logo?: File
+): Promise<ProcessResponse> {
+  const formData = new FormData()
+  formData.append('file', file)
+  formData.append('company_name', companyName)
+  formData.append('date', date.toISOString().slice(0, 10))
+  if (logo) {
+    formData.append('logo', logo)
+  }
+
+  const res = await fetch('http://localhost:8000/process', {
+    method: 'POST',
+    body: formData
+  })
+
+  if (!res.ok) {
+    const detail = await res.text()
+    throw new Error(detail || 'Failed to process template')
+  }
+
+  return res.json() as Promise<ProcessResponse>
+}

--- a/pptx-templater/src/lib/utils.ts
+++ b/pptx-templater/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}


### PR DESCRIPTION
## Summary
- add `.gitignore` exceptions so `pptx-templater/src/lib` is tracked
- implement `cn` utility and API helper for the frontend
- update backend test expectation for download endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*