### PR TITLE
Add missing frontend utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -233,3 +233,6 @@ Thumbs.db
 *.temp
 temp/
 tmp/ 
+# Allow frontend utilities
+!pptx-templater/src/lib/
+!pptx-templater/src/lib/**

--- a/pptx-templater/src/lib/api.ts
+++ b/pptx-templater/src/lib/api.ts
@@ -1,0 +1,33 @@
+export interface ProcessingResult {
+  success: boolean;
+  filename: string;
+  download_url: string;
+  message?: string;
+}
+
+export async function processTemplate(
+  file: File,
+  companyName: string,
+  date: Date,
+  logo?: File
+): Promise<ProcessingResult> {
+  const formData = new FormData();
+  formData.append("file", file);
+  formData.append("company_name", companyName);
+  formData.append("date", date.toISOString());
+  if (logo) {
+    formData.append("logo", logo);
+  }
+
+  const res = await fetch("http://localhost:8000/process", {
+    method: "POST",
+    body: formData,
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(text || "Failed to process template");
+  }
+
+  return res.json() as Promise<ProcessingResult>;
+}

--- a/pptx-templater/src/lib/utils.ts
+++ b/pptx-templater/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
## Summary
- add `processTemplate` API util
- add classnames helper in `src/lib/utils.ts`
- tweak `.gitignore` to allow tracking `src/lib`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `pytest` *(fails: No module named 'httpx')*