### PR TITLE
Fix gitignore and add lib helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,7 +99,7 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
+/lib/
 lib64/
 parts/
 sdist/

--- a/pptx-templater/src/lib/api.ts
+++ b/pptx-templater/src/lib/api.ts
@@ -1,0 +1,36 @@
+export interface ProcessTemplateResponse {
+  success: boolean;
+  filename: string;
+  download_url: string;
+  message: string;
+  processing_time?: number;
+}
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+
+export async function processTemplate(
+  file: File,
+  companyName: string,
+  date: Date,
+  logo?: File
+): Promise<ProcessTemplateResponse> {
+  const formData = new FormData();
+  formData.append('file', file);
+  formData.append('company_name', companyName);
+  formData.append('date', date.toISOString());
+  if (logo) {
+    formData.append('logo', logo);
+  }
+
+  const res = await fetch(`${API_URL}/process`, {
+    method: 'POST',
+    body: formData,
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(text || 'Failed to process template');
+  }
+
+  return res.json();
+}

--- a/pptx-templater/src/lib/utils.ts
+++ b/pptx-templater/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/pptx-templater/tsconfig.json
+++ b/pptx-templater/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",
+    "baseUrl": "./",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",


### PR DESCRIPTION
## Summary
- make `.gitignore` only ignore the root `lib/` folder
- add `src/lib` helpers for utility functions and API requests

## Testing
- `npm run build` *(fails: `next` not found)*
- `pytest -q` *(fails: `httpx` not installed)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.