### PR TITLE
Fix build by adding lib utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -232,4 +232,5 @@ Thumbs.db
 *.tmp
 *.temp
 temp/
-tmp/ 
+tmp/
+!pptx-templater/src/lib/

--- a/pptx-templater/src/lib/api.ts
+++ b/pptx-templater/src/lib/api.ts
@@ -1,0 +1,43 @@
+export interface ProcessTemplateResult {
+  download_url: string
+  filename: string
+}
+
+/**
+ * Call the backend API to process a PPTX template.
+ * @param file PPTX file to process
+ * @param companyName Company name to insert
+ * @param date Date of presentation
+ * @param logo Optional logo image
+ */
+export async function processTemplate(
+  file: File,
+  companyName: string,
+  date: Date,
+  logo?: File
+): Promise<ProcessTemplateResult> {
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8000'
+  const formData = new FormData()
+  formData.append('file', file)
+  formData.append('company_name', companyName)
+  formData.append('date', date.toISOString().slice(0, 10))
+  if (logo) {
+    formData.append('logo', logo)
+  }
+
+  const res = await fetch(`${apiUrl}/process`, {
+    method: 'POST',
+    body: formData
+  })
+
+  if (!res.ok) {
+    const message = await res.text()
+    throw new Error(message || `API request failed with status ${res.status}`)
+  }
+
+  const data = await res.json()
+  return {
+    download_url: data.download_url,
+    filename: data.filename
+  }
+}

--- a/pptx-templater/src/lib/utils.ts
+++ b/pptx-templater/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}


### PR DESCRIPTION
## Summary
- stop ignoring the frontend `src/lib` folder
- add a `cn` utility function
- add API helper for uploading the PPTX

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi==0.104.1)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*