### PR TITLE
Add helper modules and alias config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,7 @@ eggs/
 .eggs/
 lib/
 lib64/
+!pptx-templater/src/lib/
 parts/
 sdist/
 var/

--- a/pptx-templater/next.config.ts
+++ b/pptx-templater/next.config.ts
@@ -1,7 +1,11 @@
 import type { NextConfig } from "next";
+import path from "path";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  webpack(config) {
+    config.resolve.alias["@"] = path.resolve(__dirname, "src");
+    return config;
+  },
 };
 
 export default nextConfig;

--- a/pptx-templater/src/lib/api.ts
+++ b/pptx-templater/src/lib/api.ts
@@ -1,0 +1,6 @@
+export async function uploadDeck(form: FormData): Promise<Response> {
+  return fetch("/generate", {
+    method: "POST",
+    body: form,
+  });
+}

--- a/pptx-templater/src/lib/utils.ts
+++ b/pptx-templater/src/lib/utils.ts
@@ -1,0 +1,15 @@
+const ordinalRules = new Intl.PluralRules("en", { type: "ordinal" });
+const suffixes: Record<Intl.LDMLPluralRule, string> = {
+  one: "st",
+  two: "nd",
+  few: "rd",
+  other: "th",
+};
+
+export function formatDateLong(date: Date): string {
+  const day = date.getDate();
+  const month = date.toLocaleString("en", { month: "long" });
+  const year = date.getFullYear();
+  const suffix = suffixes[ordinalRules.select(day)];
+  return `${day}${suffix} ${month}, ${year}`;
+}

--- a/pptx-templater/tsconfig.json
+++ b/pptx-templater/tsconfig.json
@@ -18,8 +18,9 @@
         "name": "next"
       }
     ],
+    "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["src/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
## Summary
- add API helper to wrap `/generate` fetch
- add presentation utilities
- enable `@/` alias in tsconfig and next.js config
- allow lib directory in `.gitignore`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*