### PR TITLE
Add lib helpers and alias config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -232,4 +232,6 @@ Thumbs.db
 *.tmp
 *.temp
 temp/
-tmp/ 
+tmp/
+# Allow tracking of frontend lib directory
+!pptx-templater/src/lib/

--- a/pptx-templater/next.config.ts
+++ b/pptx-templater/next.config.ts
@@ -1,7 +1,11 @@
+import path from "path";
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  webpack(config) {
+    config.resolve.alias["@"]=path.resolve(__dirname, "src");
+    return config;
+  }
 };
 
 export default nextConfig;

--- a/pptx-templater/src/lib/api.ts
+++ b/pptx-templater/src/lib/api.ts
@@ -1,0 +1,33 @@
+export interface ProcessingResult {
+  success: boolean
+  filename: string
+  download_url: string
+  message: string
+  processing_time?: number
+}
+
+export async function processTemplate(
+  file: File,
+  companyName: string,
+  date: Date,
+  logo?: File
+): Promise<ProcessingResult> {
+  const formData = new FormData()
+  formData.append("file", file)
+  formData.append("company_name", companyName)
+  formData.append("date", date.toISOString())
+  if (logo) {
+    formData.append("logo", logo)
+  }
+
+  const res = await fetch("http://localhost:8000/process", {
+    method: "POST",
+    body: formData,
+  })
+
+  if (!res.ok) {
+    throw new Error(`Processing failed: ${res.statusText}`)
+  }
+
+  return res.json()
+}

--- a/pptx-templater/src/lib/utils.ts
+++ b/pptx-templater/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/pptx-templater/tsconfig.json
+++ b/pptx-templater/tsconfig.json
@@ -18,6 +18,7 @@
         "name": "next"
       }
     ],
+    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
## Summary
- create `src/lib/api.ts` with helper to call backend
- create `src/lib/utils.ts` with `cn` helper
- configure path aliases in `tsconfig.json`
- configure alias in `next.config.ts`
- allow tracking frontend lib directory in `.gitignore`

## Testing
- `npm run build` *(fails: `next` not found)*