### PR TITLE
Add serverless PPTX API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -232,4 +232,8 @@ Thumbs.db
 *.tmp
 *.temp
 temp/
-tmp/ 
+tmp/
+
+# Allow frontend library directory
+!pptx-templater/src/lib/
+!pptx-templater/src/lib/**

--- a/pptx-templater/package.json
+++ b/pptx-templater/package.json
@@ -26,7 +26,8 @@
     "react-dom": "^19.0.0",
     "react-dropzone": "^14.3.8",
     "tailwind-merge": "^3.3.0",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "jszip": "^3.10.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/pptx-templater/src/app/api/generate/route.ts
+++ b/pptx-templater/src/app/api/generate/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from 'next/server'
+import JSZip from 'jszip'
+
+interface TemplateParams {
+  companyName: string
+  dateLong: string
+  logo?: Buffer
+}
+
+function formatOrdinal(dateStr: string): string {
+  const d = new Date(dateStr)
+  const day = d.getDate()
+  const suffix =
+    day % 100 >= 11 && day % 100 <= 13
+      ? 'th'
+      : { 1: 'st', 2: 'nd', 3: 'rd' }[day % 10] || 'th'
+  const month = d.toLocaleString('en-US', { month: 'long' })
+  return `${day}${suffix} ${month}, ${d.getFullYear()}`
+}
+
+function buildOutputName(companyName: string, dateStr: string) {
+  const iso = dateStr.slice(0, 10).replace(/-/g, '')
+  const safe = companyName.replace(/[\\/:*?"<>|]/g, '')
+  return `${iso} ADA and ${safe} Meeting.pptx`
+}
+
+async function processPptx(template: Buffer, params: TemplateParams): Promise<Buffer> {
+  const zip = await JSZip.loadAsync(template)
+
+  const slideRegex = /^ppt\/slides\/slide\d+\.xml$/
+  const files = Object.keys(zip.files).filter(p => slideRegex.test(p))
+  await Promise.all(
+    files.map(async p => {
+      const xml = await zip.file(p)!.async('string')
+      const replaced = xml
+        .replace(/{{COMPANY_NAME}}/g, params.companyName)
+        .replace(/{{DATE_LONG}}/g, params.dateLong)
+        .replace(/{{LOGO}}/g, '')
+      zip.file(p, replaced)
+    })
+  )
+
+  // Logo insertion not fully implemented
+  if (params.logo) {
+    zip.file('ppt/media/logo.png', params.logo)
+  }
+
+  return await zip.generateAsync({ type: 'nodebuffer' })
+}
+
+export async function POST(req: Request) {
+  const form = await req.formData()
+
+  const templateFile = form.get('template') as File | null
+  const companyName = form.get('companyName') as string | null
+  const date = form.get('date') as string | null
+  const logoFile = form.get('logo') as File | null
+
+  if (!templateFile || !companyName || !date) {
+    return NextResponse.json({ error: 'Missing required fields' }, { status: 400 })
+  }
+
+  const templateBuffer = Buffer.from(await templateFile.arrayBuffer())
+  const logoBuffer = logoFile ? Buffer.from(await logoFile.arrayBuffer()) : undefined
+  const dateLong = formatOrdinal(date)
+
+  const output = await processPptx(templateBuffer, {
+    companyName,
+    dateLong,
+    logo: logoBuffer,
+  })
+
+  const filename = buildOutputName(companyName, date)
+
+  return new NextResponse(output, {
+    headers: {
+      'Content-Type':
+        'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+      'Content-Disposition': `attachment; filename="${filename}"`,
+    },
+  })
+}

--- a/pptx-templater/src/lib/api.ts
+++ b/pptx-templater/src/lib/api.ts
@@ -1,0 +1,37 @@
+export interface ProcessResult {
+  download_url: string
+  filename: string
+}
+
+export async function processTemplate(
+  file: File,
+  companyName: string,
+  date: Date,
+  logo?: File
+): Promise<ProcessResult> {
+  const formData = new FormData()
+  formData.append('template', file)
+  formData.append('companyName', companyName)
+  formData.append('date', date.toISOString())
+  if (logo) {
+    formData.append('logo', logo)
+  }
+
+  const res = await fetch('/api/generate', {
+    method: 'POST',
+    body: formData,
+  })
+
+  if (!res.ok) {
+    const text = await res.text()
+    throw new Error(text || 'Failed to generate presentation')
+  }
+
+  const blob = await res.blob()
+  const disposition = res.headers.get('Content-Disposition')
+  const filenameMatch = disposition?.match(/filename="?([^\"]+)"?/)
+  const filename = filenameMatch ? filenameMatch[1] : 'presentation.pptx'
+  const url = URL.createObjectURL(blob)
+
+  return { download_url: url, filename }
+}

--- a/pptx-templater/src/lib/utils.ts
+++ b/pptx-templater/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, ClassValue } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}


### PR DESCRIPTION
## Summary
- implement a Next.js API route to generate PPTX files
- add frontend helper to call the new API
- include `cn` util in `src/lib`
- allow committing the lib folder
- depend on `jszip` for PPTX manipulation

## Testing
- `npm run lint` *(fails: `next` not found because dependencies are missing)*